### PR TITLE
fix: Update health-coach-mcp dependencies to resolve Docker build conflicts

### DIFF
--- a/health-coach-mcp/requirements.txt
+++ b/health-coach-mcp/requirements.txt
@@ -1,8 +1,8 @@
 fastapi==0.109.0
 uvicorn[standard]==0.27.0
-pydantic==2.5.3
-pydantic-settings==2.1.0
-httpx==0.26.0
+pydantic>=2.7.0
+pydantic-settings>=2.5.2
+httpx>=0.27.0
 redis==5.0.1
 sqlmodel==0.0.14
 asyncpg==0.29.0


### PR DESCRIPTION
## Summary
- Resolves dependency conflicts preventing Docker build from completing
- Updates three package versions to satisfy MCP library requirements
- No functional changes, only dependency version updates

## Changes
- Update `httpx` from `0.26.0` to `>=0.27.0` (required by MCP library)
- Update `pydantic-settings` from `2.1.0` to `>=2.5.2` (required by MCP library)
- Update `pydantic` from `2.5.3` to `>=2.7.0` (required by pydantic-settings)

## Test Plan
- [x] Verified `pip install -r requirements.txt` completes successfully
- [x] Tested in isolated virtual environment to ensure no conflicts
- [x] Docker build should now complete without dependency resolution errors

## Context
The `fastapi-mcp` library requires newer versions of these dependencies. The previous pinned versions were causing resolution conflicts during the Docker build process.

🤖 Generated with [Claude Code](https://claude.ai/code)