### PR TITLE
hotfix: Add PostgreSQL initialization script for health_coach database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,6 +145,7 @@ services:
       - sma-net
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
 
   minio:
     image: minio/minio

--- a/init-db.sql
+++ b/init-db.sql
@@ -1,0 +1,2 @@
+-- Initialize health_coach database
+CREATE DATABASE health_coach;


### PR DESCRIPTION
## Summary
Fixes database creation issue where health-coach-mcp service expects 'health_coach' database but PostgreSQL container only creates default 'postgres' database.

- ✅ Add init-db.sql with CREATE DATABASE health_coach command
- ✅ Mount initialization script in PostgreSQL container  
- ✅ PostgreSQL automatically executes scripts in /docker-entrypoint-initdb.d/

## Test plan
- [ ] Verify health-coach-mcp service starts without database errors
- [ ] Confirm health_coach database exists in PostgreSQL container
- [ ] Test that existing services continue to work normally

🤖 Generated with [Claude Code](https://claude.ai/code)